### PR TITLE
* Solved bug where mwmbuilder.exe would fail with a start_index out o…

### DIFF
--- a/src/python/space_engineers/export.py
+++ b/src/python/space_engineers/export.py
@@ -367,7 +367,8 @@ def mwmbuilder(settings: ExportSettings, fbxfile: str, havokfile: str, paramsfil
             write_to_log(mwmfile+'.log', b"mwmbuilder skipped.")
         return
 
-    contentDir = join(settings.mwmDir, 'Content')
+    os.chdir(bpy.path.abspath("//"))
+    contentDir = join(settings.mwmDir, 'Models')
     os.makedirs(contentDir, exist_ok = True)
     basename = os.path.splitext(os.path.basename(mwmfile))[0]
 
@@ -379,7 +380,7 @@ def mwmbuilder(settings: ExportSettings, fbxfile: str, havokfile: str, paramsfil
     copy(paramsfile, join(contentDir, basename + '.xml'))
     copy(havokfile, join(contentDir, basename + '.hkt'))
 
-    cmdline = [settings.mwmbuilder, '/s:Content', '/m:'+basename+'.fbx', '/o:.\\']
+    cmdline = [settings.mwmbuilder, '/s:Models', '/m:'+basename+'.fbx', '/o:.\\']
 
     def checkForLoggedErrors(logtext):
         if b": ERROR:" in logtext:


### PR DESCRIPTION
Executing the export was returning an error on my side. Mwmbuilder was executing in a temp folder that didn't exist and looking for a subfolder that didn't exist for the file *.fbx that didn't exist.

So I added a line to change the working directory to be the .blend file directory.

Also changed so that instead of looking in Content it looks in Models which was the default export subpath of the add-on. Didn't look further to see in which variable this was stored though.